### PR TITLE
Remove dependency of "inspect" module.

### DIFF
--- a/GeoCoding.py
+++ b/GeoCoding.py
@@ -65,7 +65,7 @@ class GeoCoding:
 
     def initGui(self):
         # Create action that will start plugin
-        current_directory = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+        current_directory = os.path.dirname(os.path.abspath(__file__))
         self.action = QAction(QIcon(os.path.join(current_directory, "geocode_icon.png")), \
         "&GeoCoding", self.iface.mainWindow())
         # connect the action to the run method


### PR DESCRIPTION
Tested with QGis 3.2 64 bit from qgis.org on Windows 10 Home.
Tested with QGis 3.2 from "deb http://qgis.org/ubuntugis/ xenial main" on Ubuntu 16.04
Fixes the following error with QGis 3.2 on Windows:

```
Couldn't load plugin 'GeoCoding' due to an error when calling its initGui() method 
NameError: name 'inspect' is not defined 

```